### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/docs/minecraft/voicechat/api/examples.md
+++ b/docs/minecraft/voicechat/api/examples.md
@@ -4,7 +4,7 @@ titleTemplate: Simple Voice Chat
 
 # Examples
 
-For simplicity, all examples are using [official mappings](https://minecraft.fandom.com/wiki/Obfuscation_map).
+For simplicity, all examples are using [official mappings](https://minecraft.wiki/w/Obfuscation_map).
 
 ## Groups
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URL(s) to the new domain: minecraft.wiki